### PR TITLE
Fix crash when NetZero returns null energy_exports

### DIFF
--- a/custom_components/powerwall_control/netzero/netzero.py
+++ b/custom_components/powerwall_control/netzero/netzero.py
@@ -243,12 +243,16 @@ class EnergySiteConfig:
         return OperationalMode(self.raw_data["operational_mode"])
 
     @property
-    def energy_exports(self) -> EnergyExportMode:
+    def energy_exports(self) -> EnergyExportMode | None:
         """The grid export mode of the site.
 
         This may be one of never, pv_only, or battery_ok.
+        The API may also return null.
         """
-        return EnergyExportMode(self.raw_data["energy_exports"])
+        value = self.raw_data["energy_exports"]
+        if value is None:
+            return None
+        return EnergyExportMode(value)
 
     @property
     def grid_charging(self) -> bool:

--- a/custom_components/powerwall_control/select.py
+++ b/custom_components/powerwall_control/select.py
@@ -88,6 +88,8 @@ class PwCtrlExportModeSelectEntity(CoordinatorEntity, SelectEntity):
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         mode = self.coordinator.data.energy_exports
+        if mode is None:
+            return
         if mode == EnergyExportMode.BATTERY_OK:
             self._attr_current_option = "battery_ok"
         elif mode == EnergyExportMode.PV_ONLY:

--- a/tests/test_netzero.py
+++ b/tests/test_netzero.py
@@ -161,6 +161,18 @@ def test_energy_site_config_values():
         assert config.grid_charging == charging[i]
 
 
+def test_energy_site_config_null_energy_exports():
+    """Test EnergySiteConfig handles null energy_exports."""
+    json_cfg = {
+        "backup_reserve_percent": 80,
+        "operational_mode": "autonomous",
+        "energy_exports": None,
+        "grid_charging": True,
+    }
+    config = netzero.EnergySiteConfig(12345, json_cfg)
+    assert config.energy_exports is None
+
+
 async def test_energy_site_set_config():
     """Test EnergySite async_set_config."""
     token = "abcdef"

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -71,6 +71,25 @@ async def test_select_operational_mode(hass, mock_energysite):
         assert state.state == val[1]
 
 
+async def test_select_energy_export_mode_null(hass, mock_energysite):
+    """Test energy_export handles null from the API."""
+    state = hass.states.get("select.powerwall_energy_export_mode")
+    assert state
+    assert state.state == "pv_only"
+
+    base_config = mock_energysite.async_set_config.return_value
+    base_config.raw_data["energy_exports"] = None
+    mock_energysite.async_get_config.return_value = base_config
+
+    async_fire_time_changed(hass, utcnow() + control_cooldown_interval)
+    await hass.async_block_till_done()
+
+    # State should remain unchanged when API returns null
+    state = hass.states.get("select.powerwall_energy_export_mode")
+    assert state
+    assert state.state == "pv_only"
+
+
 async def test_select_energy_export_mode(hass, mock_energysite):
     """Test energy_export value selection."""
     test_values = [


### PR DESCRIPTION
## Summary

The integration crashes with `ValueError: None is not a valid EnergyExportMode` when the NetZero API returns `energy_exports: null` in the config response. The current workaround is to manually set a valid value via the NetZero API before the integration polls.

This PR handles `null` gracefully so the integration no longer crashes. When the API returns `null`, the HA select entity preserves its last known state.

## Changes

- **netzero.py**: `EnergySiteConfig.energy_exports` returns `None` when the raw value is `null`, instead of passing it to `EnergyExportMode()` which raises `ValueError`
- **select.py**: `_handle_coordinator_update` returns early on `None`, so HA retains the previous state rather than updating to an invalid value
- **test_netzero.py**: Added `test_energy_site_config_null_energy_exports`
- **test_select.py**: Added `test_select_energy_export_mode_null`

## Test plan

- [x] `test_energy_site_config_null_energy_exports` — verifies the config property returns `None`
- [x] `test_select_energy_export_mode_null` — verifies the select entity retains its previous state when the API returns null
- [x] Full test suite passes (33/33)